### PR TITLE
Make deeper-details a headless component: Remove the default buttons,…

### DIFF
--- a/index.css
+++ b/index.css
@@ -50,7 +50,6 @@ deeper-details:not(:defined) {
 }
 .overview-details {
   --deeperDetails-transition: max-height 900ms ease-in-out, opacity 900ms ease-in-out, transform 900ms linear;
-  /* --deeperDetails-transform--hidden: perspective(100dvh) translate3d(0, 0, -10dvh); */
   --deeperDetails-toggle-transition: transform 40ms ease-in-out, opacity 400ms linear;
 }
 .overview-details > [slot=toggler-button] {

--- a/index.html
+++ b/index.html
@@ -12,29 +12,7 @@
     <div>
       <h1><pre>Deeper-Details</pre></h1>
       <p>UX Designers have at least two different user personas browsing through their portfolios, with dramatically different constraints on time and attention.</p>
-      <deeper-details class="overview-details" showButtonLabel="Tell me more…" hideButtonLabel="Show me less…">
-        <h2>This is an H2 heading!</h2>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <p>This is a paragraph!</p>
-        <!-- Comment on the next line shows how to use a close button with your own styling -->
-        <!-- <button data-action="close" slot="close-button">Show less</button> -->
-      </deeper-details>
-
-      <deeper-details class="overview-details" showButtonLabel="Tell me more…" hideButtonLabel="Show me less…">
-        <!-- Uncomment the below button to bring your own button -->
+      <deeper-details class="overview-details">
         <button 
           slot="expand-button"
           class="slotted-toggle-button"
@@ -63,8 +41,6 @@
         <p>This is a paragraph!</p>
         <p>This is a paragraph!</p>
         <p>This is a paragraph!</p>
-        <!-- Comment on the next line shows how to use a close button with your own styling -->
-        <!-- <button data-action="close" slot="close-button">Show less</button> -->
       </deeper-details>
 
       <p>Content after</p>

--- a/src/deeper-details.ts
+++ b/src/deeper-details.ts
@@ -4,15 +4,6 @@ import { customElement, property, state } from 'lit/decorators.js'
 @customElement('deeper-details')
 export class DeeperDetails extends LitElement {
 
-  @property({type: String })
-  hideButtonLabel = 'Show less'
-
-  @property({ type: String })
-  showButtonLabel = 'Show more'
-
-  @property({ type: Boolean })
-  showHideButton? = false
-
   @property({ type: Boolean })
   _showContent = false
 
@@ -26,6 +17,35 @@ export class DeeperDetails extends LitElement {
 
     await this.updateComplete
     this._animationState = this._showContent ? 'expanded' : 'hidden'
+  }
+
+  private _handleToggleButtonSlotChange(e: Event) {
+    const slot = e.target as HTMLSlotElement
+    const buttons = slot.assignedElements().filter(el => el.tagName === 'BUTTON')
+
+    buttons.forEach(button => {
+      button.classList.add('button')
+      button.setAttribute('aria-expanded', this._showContent.toString())
+      button.setAttribute('aria-controls', 'contentWrapper')
+    })
+  }
+
+  updated(changedProperties: Map<string, any>) {
+    super.updated(changedProperties)
+
+    const updateButton = (slotName: 'expand-button' | 'hide-button') => {
+        const slot = this.shadowRoot!.querySelector(`slot[name="${slotName}"]`) as HTMLSlotElement
+        const buttons = slot.assignedElements().filter(el => el.tagName === 'BUTTON')
+        
+        buttons.forEach(button => {
+          button.setAttribute('aria-expanded', this._showContent.toString())
+        })
+    }
+  
+    if (changedProperties.has('_showContent')) {
+      updateButton('expand-button')
+      updateButton('hide-button')
+    }
   }
 
   static get styles() {
@@ -52,16 +72,6 @@ export class DeeperDetails extends LitElement {
           max-height: 0;
           opacity: var(--deeperDetails-opacity--hidden, 0);
         }
-      }
-      .button {
-        background-color: var(--deeperDetails-button-bgColor, none);
-        border: var(--deeperDetails-button-borderStyle, none);
-        color: var(--deeperDetails-button-textColor, inherit);
-        cursor: pointer;
-        font-size: var(--deeperDetails-button-fontSize, 1em);
-        font-weight: var(--deeperDetails-button-fontWeight, 400);
-        padding: var(--deeperDetails-button-padding, 0.5em 0);
-        white-space: nowrap;
       }
       .content-wrapper {
         max-height: 0;
@@ -106,18 +116,10 @@ export class DeeperDetails extends LitElement {
       <div class="deeper-details-root" data-show-content=${this._showContent} data-animation-state=${this._animationState}>
         <div class="toggle">
           <div class="toggle-element toggle-expand" aria-hidden=${this._showContent}>
-            <slot name="expand-button" @click=${this.handleToggleClick}>
-              <button class="button" aria-expanded=${this._showContent} aria-controls="contentWrapper">
-                ${this.showButtonLabel}
-              </button>
-            </slot>
+            <slot name="expand-button" @click=${this.handleToggleClick} @slotchange=${this._handleToggleButtonSlotChange}></slot>
           </div>
           <div class="toggle-element toggle-hide" aria-hidden=${!this._showContent}>
-            <slot name="hide-button" @click=${this.handleToggleClick}>
-              <button class="button" aria-expanded=${this._showContent} aria-controls="contentWrapper">
-                ${this.hideButtonLabel}
-              </button>
-            </slot>
+            <slot name="hide-button" @click=${this.handleToggleClick} @slotchange=${this._handleToggleButtonSlotChange}></slot>
           </div>
         </div>
         <div id="contentWrapper" class="content-wrapper" aria-hidden=${!this._showContent}>


### PR DESCRIPTION
… and require component consumers to bring their own buttons.